### PR TITLE
remove hardcoded name

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function ready () {
 
   function getRepos () {
     var reposReq = {
-      url: 'https://api.travis-ci.org/hooks?all=true&owner_name=finnp',
+      url: 'https://api.travis-ci.org/hooks?all=true',
       headers: travisHeaders,
       json: true
     }


### PR DESCRIPTION
Fixes a little bug in which a user name was accidentally hardcoded in the request url.
