### PR TITLE
layout tweaking

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,11 @@
       margin-bottom: 15px;
       margin-left: 5%;
     }
+
+    input:focus {
+      outline:none;
+    }
+
     .search {
       background-image: url('img/search.svg');
       padding-left: 24px;

--- a/index.html
+++ b/index.html
@@ -156,6 +156,14 @@
       background-color: #DC5753;
     }
 
+    .login {
+      margin-left: 5%;
+    }
+
+    .github {
+      margin-left: 0;
+    }
+
     </style>
     <title></title>
   </head>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,11 @@
       width: 50%;
     }
 
+    .loading {
+      margin-top: 20px;
+      margin-left: 45%;
+    }
+
     .save {
       background-color: #56B19F;
     }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     body {
       width: 100%;
       font-family: Helvetica, sans-serif;
+      margin: 0px;
     }
 
     ul, li {
@@ -13,6 +14,11 @@
       margin: 0;
       padding: 0;
     }
+
+    ul {
+      margin-bottom: 50px;
+    }
+
     li span {
       display: inline-block;
       height: 100%;
@@ -115,10 +121,12 @@
     }
 
     input {
-      width: 100%;
+      width: 83%;
       line-height: 20px;
       font-size: 14px;
+      margin-top: 5px;
       margin-bottom: 15px;
+      margin-left: 5%;
     }
     .search {
       background-image: url('img/search.svg');

--- a/index.html
+++ b/index.html
@@ -112,6 +112,9 @@
     button:active {
         box-shadow: rgba(0, 0, 0, 0.258824) 0px 0px 0px 0px;
     }
+    button:focus {
+      outline:none;
+    }
     .repo {
       padding-left: 20px;
     }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var Menu = electron.Menu
 
 var mb = menubar({
   dir: __dirname,
+  width: 450,
   icon: path.join(__dirname, 'img', 'travis-inactive.png')
 })
 

--- a/renderer.js
+++ b/renderer.js
@@ -60,7 +60,7 @@ function render () {
       var slug = repo.owner_name + '/' + repo.name
       return h('li', {key: repo.id}, [
         h('span', [
-          h('img', {
+          h('img.loading', {
             style: {visibility: repo.loading ? 'visible' : 'hidden'},
             src: loadingGif
           })
@@ -80,7 +80,7 @@ function render () {
     }))
     children.push(repoList)
   } else {
-    children.push(h('img', {
+    children.push(h('img.loading', {
       src: loadingGif
     }))
   }

--- a/renderer.js
+++ b/renderer.js
@@ -20,7 +20,7 @@ var data = {
 }
 
 function renderLogin () {
-  return h('div', {key: 'login'}, [
+  return h('div.login', {key: 'login'}, [
     h('h2', 'GitHub token'),
     h('div', [
       'Provide a ',


### PR DESCRIPTION
Thir PR suggests a few small layout tweaks. See below for a before/after.

Main thing was fixing what appeared to be a horizontal overflow due to the input bar / top button, though this could have been specific to my environment (MBA, OS X 10.11), so should be tested by others.

Other small things
- slightly wider window to better accomadate long repo names
- remove outlines on focus
- center the loading gif

If you like some but not all of these changes I'm happy to adjust! =)

Before:

![screen shot 2016-02-17 at 4 04 17 pm](https://cloud.githubusercontent.com/assets/3387500/13125104/ffe207ea-d591-11e5-8884-c2522b6fb3ba.png)

After:

![screen shot 2016-02-17 at 4 01 59 pm](https://cloud.githubusercontent.com/assets/3387500/13125109/07fb38fc-d592-11e5-8606-68b6a8142581.png)
